### PR TITLE
removed prezi because elm is not used in current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,6 @@ Inspired by Doomspork's [Elixir companies][elixir-companies] list.
   writes software.
 
 
-#### Communications
-
-* [Prezi](https://prezi.com/)
-  ([GitHub](https://github.com/prezi)) -
-  Prezi build software that enables the creation of distinctive
-  presentations.
-
-
 #### Education
 
 * [DailyDrip](https://www.dailydrip.com/)


### PR DESCRIPTION
according to https://www.quora.com/Does-Prezi-use-Elm, Prezi does not use elm anymore.